### PR TITLE
Fix date drift in IPPT tab viewmodel test

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -396,18 +396,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -689,10 +689,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:

--- a/test/presentation/viewmodels/ippt_tab_viewmodel_test.dart
+++ b/test/presentation/viewmodels/ippt_tab_viewmodel_test.dart
@@ -5,7 +5,9 @@ import 'package:ns_buddy/presentation/viewmodels/ippt_tab_viewmodel.dart';
 
 // Fake implementation for testing
 class FakeUserInfoUsecases extends UserInfoUsecases {
-  UserInfoEntity? _userInfoEntity = UserInfoEntity(dob: DateTime(2000, 1, 1));
+  UserInfoEntity? _userInfoEntity = UserInfoEntity(
+    dob: DateTime(DateTime.now().year - 25, 1, 1),
+  );
 
   @override
   UserInfoEntity? get userInfoEntity => _userInfoEntity;
@@ -209,7 +211,8 @@ void main() {
     group('resetParameters', () {
       test('should reset parameters from user entity', () {
         // Arrange
-        final dob = DateTime(2000, 1, 1); // Age ~23
+        final now = DateTime.now();
+        final dob = DateTime(now.year - 25, 1, 1);
         final enlistmentDate = DateTime(2023, 1, 1);
         final ordDate = DateTime(2025, 1, 1);
         fakeUserInfoUsecases.setUserInfo(
@@ -230,7 +233,7 @@ void main() {
         viewModel.resetParameters();
 
         // Assert
-        expect(viewModel.age, greaterThanOrEqualTo(23));
+        expect(viewModel.age, 25);
         expect(viewModel.isShiongVocLocal, true);
         expect(viewModel.isEdited, false);
       });
@@ -310,15 +313,15 @@ void main() {
     group('date of birth age derivation', () {
       test('should derive age correctly from DOB', () {
         // Arrange
-        final dob = DateTime(2000, 1, 1); // Should be ~24-25 years old
+        final now = DateTime.now();
+        final dob = DateTime(now.year - 24, now.month, now.day);
         fakeUserInfoUsecases.setUserInfo(UserInfoEntity(dob: dob));
 
         // Act
         viewModel.resetParameters();
 
         // Assert
-        expect(viewModel.age, greaterThanOrEqualTo(23));
-        expect(viewModel.age, lessThanOrEqualTo(25));
+        expect(viewModel.age, 24);
       });
 
       test('should handle birthday calculation correctly', () {
@@ -367,7 +370,7 @@ void main() {
         final ordDate = now.add(const Duration(days: 365));
         fakeUserInfoUsecases.setUserInfo(
           UserInfoEntity(
-            dob: DateTime(2000, 1, 1),
+            dob: DateTime(now.year - 20, 1, 1),
             enlistmentDate: enlistmentDate,
             ordDate: ordDate,
           ),
@@ -382,9 +385,10 @@ void main() {
 
       test('should handle missing service dates', () {
         // Arrange
+        final now = DateTime.now();
         fakeUserInfoUsecases.setUserInfo(
           UserInfoEntity(
-            dob: DateTime(2000, 1, 1),
+            dob: DateTime(now.year - 20, 1, 1),
             enlistmentDate: null,
             ordDate: null,
           ),


### PR DESCRIPTION
Update hardcoded birth dates in ippt_tab_viewmodel_test.dart to be calculated dynamically relative to DateTime.now(), resolving test failures due to age calculation drift.

Fixes #3

---
*PR created automatically by Jules for task [10249308709146011456](https://jules.google.com/task/10249308709146011456) started by @gabriel-lau*